### PR TITLE
Add copy: true to grunt-bower-task configuration to maintain previous behaviour

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function (grunt) {
         bower: {
             install: {
                 options: {
+                    copy: true,
                     layout: function (type, component, source) {
                         return type;
                     },


### PR DESCRIPTION
Version 0.4.0 of the `grunt-bower-task` module use the `copy: true` behaviour by default, now that this operator uses 0.5.0, this has to be configured explicitly.