### PR TITLE
Add metadata output

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.0.0">
+<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.1.0">
     <details>
         <title>NGSI source</title>
         <homepage>https://github.com/wirecloud-fiware/ngsi-source</homepage>
@@ -81,6 +81,7 @@
     </preferences>
     <wiring>
         <outputendpoint name="entityOutput" type="text" label="Entities" description="Initial entity values and entity updates" friendcode="entity-list"/>
+        <outputendpoint name="ngsimetadata" type="text" label="NGSI metadata" description="Metadata of the NGSI config usable on wizards creating data dashboards such as NGSI-dashboard-creatorI" friendcode="ngsi-metadata" />
     </wiring>
     <scripts>
         <script src="lib/js/moment-with-locales.min.js"/>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -64,7 +64,7 @@
 
         // Create NGSI conection
         doInitialSubscription.call(this);
-        
+
         // Initial sent of configs on metadata output endpoint
         sendMetadata();
     };
@@ -272,7 +272,8 @@
         if (MashupPlatform.operator.outputs.ngsimetadata.connected) {
             var metadata = {
                 types: MashupPlatform.prefs.get('ngsi_entities').trim().split(","),
-                filteredAttributes: MashupPlatform.prefs.get('ngsi_update_attributes').trim().split(","),
+                filteredAttributes: "",  // This widget does not have such information
+                updateAttributes: MashupPlatform.prefs.get('ngsi_update_attributes').trim().split(","),
                 // entity: response.result.entity, // For future support of fiware-ngsi-registry
                 auth_type: "",  // Not present in NGSI-source
                 idPattern: MashupPlatform.prefs.get('ngsi_id_filter').trim(),

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -64,6 +64,9 @@
 
         // Create NGSI conection
         doInitialSubscription.call(this);
+        
+        // Initial sent of configs on metadata output endpoint
+        sendMetadata();
     };
 
     /* *****************************************************************************/
@@ -235,6 +238,8 @@
 
     var handlerPreferences = function handlerPreferences(new_values) {
 
+        sendMetadata();
+
         if (this.refresh_interval) {
             clearInterval(this.refresh_interval);
             this.refresh_interval = null;
@@ -262,6 +267,27 @@
             doInitialSubscription.call(this);
         }
     };
+
+    var sendMetadata = function sendMetadata() {
+        if (MashupPlatform.operator.outputs.ngsimetadata.connected) {
+            var metadata = {
+                types: MashupPlatform.prefs.get('ngsi_entities').trim().split(","),
+                filteredAttributes: MashupPlatform.prefs.get('ngsi_update_attributes').trim().split(","),
+                // entity: response.result.entity, // For future support of fiware-ngsi-registry
+                auth_type: "",  // Not present in NGSI-source
+                idPattern: MashupPlatform.prefs.get('ngsi_id_filter').trim(),
+                query: MashupPlatform.prefs.get('query').trim(),
+                values: false, // Not needed in NGSI-source
+                serverURL: MashupPlatform.prefs.get('ngsi_server').trim(),
+                proxyURL: MashupPlatform.prefs.get('ngsi_proxy').trim(),
+                servicePath: MashupPlatform.prefs.get('ngsi_service_path').trim(),
+                tenant: MashupPlatform.prefs.get('ngsi_tenant').trim(),
+                // use_owner_credentials: false,
+                // use_user_fiware_token: false,
+            };
+            MashupPlatform.wiring.pushEvent('ngsimetadata', metadata);
+        }
+    }
 
     /* import-block */
     window.NGSISource = NGSISource;

--- a/tests/js/NGSISourceSpec.js
+++ b/tests/js/NGSISourceSpec.js
@@ -23,7 +23,7 @@
                     'use_owner_credentials': false,
                     'use_user_fiware_token': false
                 },
-                outputs: ['entityOutput']
+                outputs: ['entityOutput', 'ngsimetadata']
             });
         });
 


### PR DESCRIPTION
Add a metadata output compatible with the one used betwen [ckan-metadata-operator](https://github.com/Wirecloud/ckan-metadata-operator) and [NGSI-dashboardCreatorWidget](https://github.com/Wirecloud/NGSI-dashboard-creator-widget)