### PR TITLE
Feature/skip initial notification

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,6 +150,11 @@ module.exports = function (grunt) {
                     }
                 }
             },
+            operatordebug: {
+                options: {
+                    singleRun: false
+                }
+            },
             operatorci: {
                 options: {
                     junitReporter: {

--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.2.0b1">
+<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.2.0b2">
     <details>
         <title>NGSI source</title>
         <homepage>https://github.com/wirecloud-fiware/ngsi-source</homepage>

--- a/src/doc/changelog.es.md
+++ b/src/doc/changelog.es.md
@@ -2,6 +2,9 @@
 
 - Añadido un nuevo endpoint de salida para obtener las entidades usando el
     formato `normalized`.
+- Uso de la opción `skipInitialNotification` para evitar recibir la
+  notificación inicial que manda por defecto el Context Broker Orion. Requiere
+  WireCloud 1.4+ para que tenga efecto.
 
 
 ## v4.0.0 (2017-12-07)

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -2,6 +2,9 @@
 
 - Added a new output endpoint for retrieving entities using the `normalized`
   format.
+- Use the `skipInitialNotification` option to avoid receiving the initial
+  notification usually sent by the orion context broker. Requires WireCloud 1.4+
+  to take effect.
 
 
 ## v4.0.0 (2017-12-07)

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -167,6 +167,8 @@
                     }
                 },
                 expires: moment().add('3', 'hours').toISOString()
+            }, {
+                skipInitialNotification: true
             }).then(
                 (response) => {
                     MashupPlatform.operator.log("Subscription created successfully (id: " + response.subscription.id + ")", MashupPlatform.log.INFO);


### PR DESCRIPTION
This PR updates operator code to use the `skipInitialNotification` option when creating context broker subscription. This option requires Orion Context Broker v2.2.0. In any case, this operator will still work with previous versions of the context broker.