### PR TITLE
Allow to configure what attributes and what metadata to request to the context broker

### DIFF
--- a/src/config.xml
+++ b/src/config.xml
@@ -73,6 +73,12 @@
             description="Filter entities by providing a query using the Simple Query Language."
             default="" />
         <preference
+            name="ngsi_attributes"
+            type="text"
+            label="Requested Attributes"
+            description="A comma separated list of attribute names or the `*` wildcard. Use `*` or an empty value to request all attributes except the builtin ones (`dateCreated`, `dateModified`, ...)."
+            default="*" />
+        <preference
             name="ngsi_metadata"
             type="text"
             label="Requested Metadata"

--- a/src/config.xml
+++ b/src/config.xml
@@ -73,6 +73,12 @@
             description="Filter entities by providing a query using the Simple Query Language."
             default="" />
         <preference
+            name="ngsi_metadata"
+            type="text"
+            label="Requested Metadata"
+            description="A comma separated list of attribute metadata names or the `*` wildcard. Use `*` or an empty value to request all attribute matadata except the builtin ones (`dateCreated`, `dateModified`, ...)."
+            default="*" />
+        <preference
             name="ngsi_update_attributes"
             type="text"
             label="Monitored NGSI Attributes"

--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.2.0rc1">
+<operator xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-source" version="4.2.0rc2">
     <details>
         <title>NGSI source</title>
         <homepage>https://github.com/wirecloud-fiware/ngsi-source</homepage>

--- a/src/doc/changelog.es.md
+++ b/src/doc/changelog.es.md
@@ -8,6 +8,8 @@
 - Añadida la opción de subscribirse a los cambios en cualquiera de los
   atributos mediante el uso de comodín `*` en la preferencia **Monitored NGSI
   Attributes**.
+- Soporte para poder configurar que atributos y que metadatos van a ser pedidos
+  al context broker.
 
 
 ## v4.0.0 (2017-12-07)

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -7,6 +7,8 @@
   to take effect.
 - Allow to monitor all entity attributes by providing the `*` value on the
   **Monitored NGSI Attributes** setting.
+- Allow to configure what attributes and metadata values are going to be
+  requested to the context broker.
 
 
 ## v4.0.0 (2017-12-07)

--- a/src/doc/userguide.md
+++ b/src/doc/userguide.md
@@ -35,13 +35,16 @@ Settings
   empty, in that case, entities won't be filtered by id.
 - **Query:** Filter entities by providing a query using the Simple Query
   Language.
+- **Requested Attributes:** A comma separated list of attribute names or the `*`
+  wildcard. Use `*` or an empty value to request all attributes except the
+  builtin ones (`dateCreated`, `dateModified`, ...).
+- **Requested Metadata:** A comma separated list of attribute metadata names or
+  the `*` wildcard. Use `*` or an empty value to request all attribute matadata
+  except the builtin ones (`dateCreated`, `dateModified`, ...).
 - **Monitored NGSI Attributes:** Attributes to monitor for updates. Those
   changes are tracked by creating a subscription inside the context broker. If
   this list is empty, that subscription won't be created. Use `*` to subscribe
   to changes on any attribute.
-- **attributes format ('keyValues', 'normalized' or 'values'):** Specifies how
-  the entities are represented in notifications. Accepted values are 'normalized'
-  (default), 'keyValues' or 'values'.
 
 
 Wiring

--- a/tests/js/NGSISourceSpec.js
+++ b/tests/js/NGSISourceSpec.js
@@ -32,10 +32,11 @@
                     'query': '',
                     'ngsi_entities': '',
                     'ngsi_id_filter': '',
+                    'ngsi_metadata': '*',
                     'ngsi_proxy': 'https://ngsiproxy.example.com',
                     'ngsi_server': 'https://orion.example.com',
-                    'ngsi_tenant': 'Tenant',
                     'ngsi_service_path': '/Spain/Madrid',
+                    'ngsi_tenant': 'Tenant',
                     'ngsi_update_attributes': '',
                     'use_owner_credentials': false,
                     'use_user_fiware_token': false

--- a/tests/js/NGSISourceSpec.js
+++ b/tests/js/NGSISourceSpec.js
@@ -30,6 +30,7 @@
                 type: 'operator',
                 prefs: {
                     'query': '',
+                    'ngsi_attributes': '*',
                     'ngsi_entities': '',
                     'ngsi_id_filter': '',
                     'ngsi_metadata': '*',

--- a/tests/js/NGSISourceSpec.js
+++ b/tests/js/NGSISourceSpec.js
@@ -335,6 +335,46 @@
             }, 0);
         });
 
+        it("connect (custom attributes)", (done) => {
+            MashupPlatform.prefs.set('ngsi_attributes', 'speed,location');
+            MashupPlatform.prefs.set('ngsi_update_attributes', 'location');
+            MashupPlatform.operator.outputs.entityOutput.connect(true);
+
+            operator.init();
+
+            setTimeout(() => {
+                // List Entities Options
+                const leo = operator.connection.v2.listEntities.calls.mostRecent().args[0];
+                expect(leo.attrs).toEqual("speed,location");
+
+                // Create Subscription Options
+                const cso = operator.connection.v2.createSubscription.calls.mostRecent().args[0];
+
+                expect(cso.notification.attrs).toEqual(["speed", "location"]);
+                done();
+            });
+        });
+
+        it("connect (custom metadata)", (done) => {
+            MashupPlatform.prefs.set('ngsi_metadata', 'unitCode,timestamp');
+            MashupPlatform.prefs.set('ngsi_update_attributes', 'location');
+            MashupPlatform.operator.outputs.entityOutput.connect(true);
+
+            operator.init();
+
+            setTimeout(() => {
+                // List Entities Options
+                const leo = operator.connection.v2.listEntities.calls.mostRecent().args[0];
+                expect(leo.metadata).toEqual("unitCode,timestamp");
+
+                // Create Subscription Options
+                const cso = operator.connection.v2.createSubscription.calls.mostRecent().args[0];
+
+                expect(cso.notification.metadata).toEqual(["unitCode", "timestamp"]);
+                done();
+            });
+        });
+
         it("connect (types + subscription)", (done) => {
             MashupPlatform.operator.outputs.entityOutput.connect(true);
             MashupPlatform.prefs.set('ngsi_entities', 'AirQualityObserved, WeatherForecast');


### PR DESCRIPTION
This PR updates operator settings to allow to configure what attributes and what metadata is going to be requested to the context broker. Those new settings can also be used to include builtin attributes/metadata so this PR supersedes PR #27. 